### PR TITLE
Add support for configurable path prefix via MCP_PATH_PREFIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ MCP Server for VictoriaLogs is configured via environment variables:
 | `VL_INSTANCE_BEARER_TOKEN` | Authentication token for VictoriaLogs API               | No       | -                | -                      |
 | `MCP_SERVER_MODE`          | Server operation mode. See [Modes](#modes) for details. | No       | `stdio`          | `stdio`, `sse`, `http` |
 | `MCP_LISTEN_ADDR`          | Address for SSE or HTTP server to listen on             | No       | `localhost:8081` | -                      |
+| `MCP_PATH_PREFIX`          | Path prefix for all endpoints (useful for ingress deployments) | No | -              | -                      |
 | `MCP_DISABLED_TOOLS`       | Comma-separated list of tools to disable                | No       | -                | -                      |
 | `MCP_HEARTBEAT_INTERVAL`   | Defines the heartbeat interval for the streamable-http protocol. <br /> It means the MCP server will send a heartbeat to the client through the GET connection, <br /> to keep the connection alive from being closed by the network infrastructure (e.g. gateways) | No | `30s`  | -   |
 
@@ -176,6 +177,9 @@ export VL_INSTANCE_ENTRYPOINT="https://play-vmlogs.victoriametrics.com"
 export MCP_SERVER_MODE="sse"
 export MCP_SSE_ADDR="0.0.0.0:8081"
 export MCP_DISABLED_TOOLS="hits,facets"
+
+# Path prefix for ingress deployments
+export MCP_PATH_PREFIX="/victoria-logs/production"
 ```
 
 ## Endpoints
@@ -189,6 +193,8 @@ In SSE and HTTP modes the MCP server provides the following endpoints:
 | `/metrics`          | Metrics in Prometheus format for monitoring the MCP server                                       |
 | `/health/liveness`  | Liveness check endpoint to ensure the server is running                                          |
 | `/health/readiness` | Readiness check endpoint to ensure the server is ready to accept requests                        |
+
+**Note:** When `MCP_PATH_PREFIX` is configured, all endpoints will be prefixed with the specified path. For example, with `MCP_PATH_PREFIX="/victoria-logs/production"`, the `/metrics` endpoint becomes `/victoria-logs/production/metrics`.
 
 ## Setup in clients
 

--- a/cmd/mcp-victorialogs/config/config.go
+++ b/cmd/mcp-victorialogs/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	bearerToken       string
 	disabledTools     map[string]bool
 	heartbeatInterval time.Duration
+	pathPrefix        string
 
 	entryPointURL *url.URL
 }
@@ -51,6 +52,7 @@ func InitConfig() (*Config, error) {
 		bearerToken:       os.Getenv("VL_INSTANCE_BEARER_TOKEN"),
 		disabledTools:     disabledToolsMap,
 		heartbeatInterval: heartbeatInterval,
+		pathPrefix:        os.Getenv("MCP_PATH_PREFIX"),
 	}
 	// Left for backward compatibility
 	if result.listenAddr == "" {
@@ -116,4 +118,8 @@ func (c *Config) HeartbeatInterval() time.Duration {
 		return 30 * time.Second // Default heartbeat interval
 	}
 	return c.heartbeatInterval
+}
+
+func (c *Config) PathPrefix() string {
+	return c.pathPrefix
 }


### PR DESCRIPTION
This enables easier ingress deployment by allowing all endpoints to be prefixed with a configurable path. Addresses path-based routing challenges in Kubernetes deployments.

- Add MCP_PATH_PREFIX environment variable to config
- Update all HTTP endpoints to use configurable prefix
- Configure SSE server with static base path when prefix is set
- Maintain backward compatibility when prefix is not set

Fixes #14