### PR TITLE
implement new parameter MCP_PASSTHROUGH_HEADER that  allows to forwar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ MCP Server for VictoriaLogs is configured via environment variables:
 | `VL_INSTANCE_ENTRYPOINT`   | URL to VictoriaLogs instance                                                                                                                                                                                                                                        | Yes      | -                | -                                |
 | `VL_INSTANCE_BEARER_TOKEN` | Authentication token for VictoriaLogs API                                                                                                                                                                                                                           | No       | -                | -                                |
 | `VL_INSTANCE_HEADERS`      | Custom HTTP headers to send with requests (comma-separated key=value pairs)                                                                                                                                                                                         | No       | -                | -                                |
+| `MCP_PASSTHROUGH_HEADERS`  | HTTP header names to forward from incoming MCP requests to VictoriaLogs (comma-separated list). Overrides `VL_INSTANCE_HEADERS` on collision. Only applies in `sse`/`http` modes.                                                                                   | No       | -                | -                                |
 | `VL_DEFAULT_TENANT_ID`     | Default tenant ID used when tenant is not specified in requests (format: `AccountID:ProjectID` or `AccountID`)                                                                                                                                                      | No       | `0:0`            | -                                |
 | `MCP_SERVER_MODE`          | Server operation mode. See [Modes](#modes) for details.                                                                                                                                                                                                             | No       | `stdio`          | `stdio`, `sse`, `http`           |
 | `MCP_LISTEN_ADDR`          | Address for SSE or HTTP server to listen on                                                                                                                                                                                                                         | No       | `localhost:8081` | -                                |
@@ -157,6 +158,9 @@ export VL_INSTANCE_ENTRYPOINT="https://play-vmlogs.victoriametrics.com"
 # Custom headers for authentication (e.g., behind a reverse proxy)
 # Expected syntax is key=value separated by commas
 export VL_INSTANCE_HEADERS="<HEADER>=<HEADER_VALUE>,<HEADER>=<HEADER_VALUE>"
+
+# Forward specific headers from incoming MCP requests to VictoriaLogs
+export MCP_PASSTHROUGH_HEADERS="X-Token,X-Access-Key"
 
 # Server mode
 export MCP_SERVER_MODE="sse"

--- a/cmd/mcp-victorialogs/config/config.go
+++ b/cmd/mcp-victorialogs/config/config.go
@@ -11,14 +11,15 @@ import (
 )
 
 type Config struct {
-	serverMode        string
-	listenAddr        string
-	entrypoint        string
-	bearerToken       string
-	customHeaders     map[string]string
-	disabledTools     map[string]bool
-	heartbeatInterval time.Duration
-	defaultTenantID   logstorage.TenantID
+	serverMode         string
+	listenAddr         string
+	entrypoint         string
+	bearerToken        string
+	customHeaders      map[string]string
+	passthroughHeaders []string
+	disabledTools      map[string]bool
+	heartbeatInterval  time.Duration
+	defaultTenantID    logstorage.TenantID
 
 	entryPointURL *url.URL
 
@@ -57,6 +58,17 @@ func InitConfig() (*Config, error) {
 		}
 	}
 
+	var passthroughHeaders []string
+	passthroughHeadersStr := os.Getenv("MCP_PASSTHROUGH_HEADERS")
+	if passthroughHeadersStr != "" {
+		for _, h := range strings.Split(passthroughHeadersStr, ",") {
+			h = strings.TrimSpace(h)
+			if h != "" {
+				passthroughHeaders = append(passthroughHeaders, h)
+			}
+		}
+	}
+
 	heartbeatInterval := 30 * time.Second
 	heartbeatIntervalStr := os.Getenv("MCP_HEARTBEAT_INTERVAL")
 	if heartbeatIntervalStr != "" {
@@ -87,16 +99,17 @@ func InitConfig() (*Config, error) {
 	}
 
 	result := &Config{
-		serverMode:        strings.ToLower(os.Getenv("MCP_SERVER_MODE")),
-		listenAddr:        os.Getenv("MCP_LISTEN_ADDR"),
-		entrypoint:        os.Getenv("VL_INSTANCE_ENTRYPOINT"),
-		bearerToken:       os.Getenv("VL_INSTANCE_BEARER_TOKEN"),
-		customHeaders:     customHeadersMap,
-		disabledTools:     disabledToolsMap,
-		heartbeatInterval: heartbeatInterval,
-		logFormat:         logFormat,
-		logLevel:          logLevel,
-		defaultTenantID:   logstorage.TenantID{AccountID: 0, ProjectID: 0},
+		serverMode:         strings.ToLower(os.Getenv("MCP_SERVER_MODE")),
+		listenAddr:         os.Getenv("MCP_LISTEN_ADDR"),
+		entrypoint:         os.Getenv("VL_INSTANCE_ENTRYPOINT"),
+		bearerToken:        os.Getenv("VL_INSTANCE_BEARER_TOKEN"),
+		customHeaders:      customHeadersMap,
+		passthroughHeaders: passthroughHeaders,
+		disabledTools:      disabledToolsMap,
+		heartbeatInterval:  heartbeatInterval,
+		logFormat:          logFormat,
+		logLevel:           logLevel,
+		defaultTenantID:    logstorage.TenantID{AccountID: 0, ProjectID: 0},
 	}
 	// Left for backward compatibility
 	if result.listenAddr == "" {
@@ -172,6 +185,10 @@ func (c *Config) HeartbeatInterval() time.Duration {
 
 func (c *Config) CustomHeaders() map[string]string {
 	return c.customHeaders
+}
+
+func (c *Config) PassthroughHeaders() []string {
+	return c.passthroughHeaders
 }
 
 func (c *Config) LogFormat() string {

--- a/cmd/mcp-victorialogs/config/config_test.go
+++ b/cmd/mcp-victorialogs/config/config_test.go
@@ -15,6 +15,7 @@ func TestInitConfig(t *testing.T) {
 	originalBearerToken := os.Getenv("VL_INSTANCE_BEARER_TOKEN")
 	originalHeartbeatInterval := os.Getenv("MCP_HEARTBEAT_INTERVAL")
 	originalDefaultTenantID := os.Getenv("VL_DEFAULT_TENANT_ID")
+	originalPassthroughHeaders := os.Getenv("MCP_PASSTHROUGH_HEADERS")
 
 	// Restore environment variables after test
 	defer func() {
@@ -24,6 +25,7 @@ func TestInitConfig(t *testing.T) {
 		os.Setenv("VL_INSTANCE_BEARER_TOKEN", originalBearerToken)
 		os.Setenv("MCP_HEARTBEAT_INTERVAL", originalHeartbeatInterval)
 		os.Setenv("VL_DEFAULT_TENANT_ID", originalDefaultTenantID)
+		os.Setenv("MCP_PASSTHROUGH_HEADERS", originalPassthroughHeaders)
 	}()
 
 	// Test case 1: Valid configuration
@@ -311,6 +313,70 @@ func TestInitConfig(t *testing.T) {
 		_, err := InitConfig()
 		if err == nil {
 			t.Fatal("Expected error for invalid tenant ID format, got nil")
+		}
+	})
+
+	// Test case: Passthrough headers parsing
+	t.Run("Passthrough headers parsing", func(t *testing.T) {
+		os.Setenv("VL_INSTANCE_ENTRYPOINT", "http://example.com")
+		os.Setenv("VL_DEFAULT_TENANT_ID", "")
+		os.Setenv("MCP_PASSTHROUGH_HEADERS", "Authorization,X-Custom-Token,X-Request-ID")
+
+		cfg, err := InitConfig()
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		headers := cfg.PassthroughHeaders()
+		expected := []string{"Authorization", "X-Custom-Token", "X-Request-ID"}
+
+		if len(headers) != len(expected) {
+			t.Fatalf("Expected %d passthrough headers, got %d", len(expected), len(headers))
+		}
+		for i, h := range headers {
+			if h != expected[i] {
+				t.Errorf("Expected header %q at index %d, got %q", expected[i], i, h)
+			}
+		}
+	})
+
+	// Test case: Empty passthrough headers
+	t.Run("Empty passthrough headers", func(t *testing.T) {
+		os.Setenv("VL_INSTANCE_ENTRYPOINT", "http://example.com")
+		os.Setenv("VL_DEFAULT_TENANT_ID", "")
+		os.Setenv("MCP_PASSTHROUGH_HEADERS", "")
+
+		cfg, err := InitConfig()
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if len(cfg.PassthroughHeaders()) != 0 {
+			t.Errorf("Expected 0 passthrough headers, got %d", len(cfg.PassthroughHeaders()))
+		}
+	})
+
+	// Test case: Passthrough headers with whitespace and empty entries
+	t.Run("Passthrough headers whitespace trimming", func(t *testing.T) {
+		os.Setenv("VL_INSTANCE_ENTRYPOINT", "http://example.com")
+		os.Setenv("VL_DEFAULT_TENANT_ID", "")
+		os.Setenv("MCP_PASSTHROUGH_HEADERS", " Authorization , , X-Custom-Token , ")
+
+		cfg, err := InitConfig()
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		headers := cfg.PassthroughHeaders()
+		expected := []string{"Authorization", "X-Custom-Token"}
+
+		if len(headers) != len(expected) {
+			t.Fatalf("Expected %d passthrough headers, got %d", len(expected), len(headers))
+		}
+		for i, h := range headers {
+			if h != expected[i] {
+				t.Errorf("Expected header %q at index %d, got %q", expected[i], i, h)
+			}
 		}
 	})
 }

--- a/cmd/mcp-victorialogs/tools/utils.go
+++ b/cmd/mcp-victorialogs/tools/utils.go
@@ -38,6 +38,13 @@ func CreateSelectRequest(ctx context.Context, cfg *config.Config, tcr mcp.CallTo
 		req.Header.Set(key, value)
 	}
 
+	// Apply passthrough headers from the incoming MCP request
+	for _, name := range cfg.PassthroughHeaders() {
+		if value := tcr.Header.Get(name); value != "" {
+			req.Header.Set(name, value)
+		}
+	}
+
 	defaultTenantID := cfg.DefaultTenantID()
 	if accountID == "" {
 		accountID = strconv.FormatUint(uint64(defaultTenantID.AccountID), 10)
@@ -70,6 +77,13 @@ func CreateAdminRequest(ctx context.Context, cfg *config.Config, tcr mcp.CallToo
 	// Add custom headers from configuration
 	for key, value := range cfg.CustomHeaders() {
 		req.Header.Set(key, value)
+	}
+
+	// Apply passthrough headers from the incoming MCP request
+	for _, name := range cfg.PassthroughHeaders() {
+		if value := tcr.Header.Get(name); value != "" {
+			req.Header.Set(name, value)
+		}
 	}
 
 	return req, nil

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -55,6 +55,10 @@ spec:
             - name: VL_INSTANCE_HEADERS
               value: "{{ join "," . }}"
             {{- end }}
+            {{- with .Values.mcp.passthroughHeaders }}
+            - name: MCP_PASSTHROUGH_HEADERS
+              value: "{{ join "," . }}"
+            {{- end }}
             {{- with .Values.mcp.disable.resources }}
             - name: MCP_DISABLE_RESOURCES
               value: "{{ . }}"

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -41,6 +41,7 @@ mcp:
     tools: []
     resources: false
   heartbeatInterval: 30s
+  passthroughHeaders: []
 
 vl:
   entrypoint: ""


### PR DESCRIPTION
…d HTTP headers from incoming MCP requests to VictoriaLogs instance, it can be used for authorization and routing between multiple instances.