### PR TITLE
Fix Gemini CLI config command syntax

### DIFF
--- a/web/src/components/tabs/client-configs.tsx
+++ b/web/src/components/tabs/client-configs.tsx
@@ -170,7 +170,7 @@ export function ClientConfigs() {
       title: "Gemini CLI",
       description: "Google's AI coding agent for the terminal",
       icon: <Gemini className="h-6 w-6" />,
-      config: `gemini mcp add --name victorialogs --transport http ${serverUrl}/mcp`,
+      config: `gemini mcp add victorialogs --transport http ${serverUrl}/mcp`,
     },
     {
       title: "OpenCode",


### PR DESCRIPTION
Fix syntax issue with gemini CLI

```
gemini mcp add -h
Usage: gemini mcp add [options] <name> <commandOrUrl> [args...]

Positionals:
  name          Name of the server                                                                                                             [string] [required]
  commandOrUrl  Command (stdio) or URL (sse, http)                                                                                             [string] [required]

Options:
  -d, --debug              Run in debug mode (open debug console with F12)                                                              [boolean] [default: false]
  -s, --scope              Configuration scope (user or project)                                        [string] [choices: "user", "project"] [default: "project"]
  -t, --transport, --type  Transport type (stdio, sse, http)                                         [string] [choices: "stdio", "sse", "http"] [default: "stdio"]
  -e, --env                Set environment variables (e.g. -e KEY=value)                                                                                   [array]
  -H, --header             Set HTTP headers for SSE and HTTP transports (e.g. -H "X-Api-Key: abc123" -H "Authorization: Bearer abc123")                    [array]
      --timeout            Set connection timeout in milliseconds                                                                                         [number]
      --trust              Trust the server (bypass all tool call confirmation prompts)                                                                  [boolean]
      --description        Set the description for the server                                                                                             [string]
      --include-tools      A comma-separated list of tools to include                                                                                      [array]
      --exclude-tools      A comma-separated list of tools to exclude                                                                                      [array]
  -h, --help               Show help
```